### PR TITLE
Fix arg0 under clang to allow openmp option

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -1,5 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf bin
 mkdir bin
-g++ -march=native -fopenmp -Ofast *.cpp -o bin/bebbsum
+if [[ "$(basename "$(readlink "$(which c++)")")" == clang++* ]]; then 
+	clang++ -march=native -fopenmp -Ofast *.cpp -o bin/bebbsum
+else
+	c++ -march=native -fopenmp -Ofast *.cpp -o bin/bebbsum
+fi


### PR DESCRIPTION
For some reason, clang doesn't like `-fopenmp` when it's operating in `c++`/`g++` compatibility mode (when its arg0 is different).

This does a quick check to see if clang looks like it's being used and will select the compiler name based on that.